### PR TITLE
Improve HS80 battery/charging detection and add LED controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ CMakeLists.txt.user*
 # --------
 *.dll
 *.exe
+/test_leds
 
 # Directories with generated files
 .moc/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,4 +18,10 @@ set_target_properties(hs80tray PROPERTIES
 )
 target_include_directories(hs80tray PRIVATE ${HIDAPI_INCLUDE_DIRS})
 target_link_libraries(hs80tray Qt6::DBus KF6::StatusNotifierItem Qt6::Widgets ${HIDAPI_LIBRARIES})
+
+add_executable(test_leds test_leds.cpp)
+set_target_properties(test_leds PROPERTIES AUTOMOC OFF)
+target_include_directories(test_leds PRIVATE ${HIDAPI_INCLUDE_DIRS})
+target_link_libraries(test_leds ${HIDAPI_LIBRARIES})
+
 install(TARGETS hs80tray DESTINATION bin)

--- a/HS80_FINDINGS.md
+++ b/HS80_FINDINGS.md
@@ -1,0 +1,36 @@
+# Corsair HS80 RGB Wireless (0x0A6B) - Linux HID Protocol
+
+## Device Info
+- **Vendor ID**: 0x1B1C
+- **Product ID**: 0x0A6B
+- **Primary Interface**: Interface 3 (Handles both RGB and Status)
+
+## 1. Handshake (Software Mode)
+Send these to Interface 3 to enable custom control:
+1. `02 09 01 03 00 02` (Software Mode Enable)
+2. `02 09 0D 00 01` (Open Lighting Endpoint)
+
+*Note: Repeat these periodically (every 1-5s) to prevent the firmware from reverting to Hardware Mode.*
+
+## 2. LED Control (Interleaved RGB)
+**Report ID**: 02, **Wireless Mode**: 09, **Command**: 06
+Format: `02 09 06 00 09 00 00 00 [R0 R1 R2] [G0 G1 G2] [B0 B1 B2]`
+
+### Verified Zone Mapping
+- **Index 0**: Logo LED
+- **Index 1**: Power LED
+- **Index 2**: Microphone LED
+
+### Example: Power Green, Others Off
+- Rossi (0, 0, 0): `00 00 00`
+- Verdi (0, 255, 0): `00 FF 00`
+- Blu   (0, 0, 0): `00 00 00`
+**Full Packet**: `02 09 06 00 09 00 00 00 00 00 00 00 FF 00 00 00 00`
+
+## 3. Status Monitoring (Mute/Battery)
+**Report ID**: 03
+**Event Code**: A6 (Microphone Status)
+- **Byte 6 (Index 5)**: `01` (Muted/Up), `00` (Active/Down)
+
+**Event Code**: 0F (Battery Level)
+- **Byte 6-7 (Index 5-6)**: 16-bit Little Endian (Value / 10 = %)

--- a/HS80_FINDINGS.md
+++ b/HS80_FINDINGS.md
@@ -4,7 +4,7 @@
 Per evitare disconnessioni del dongle, la comunicazione deve seguire un ritmo costante e non eccessivo:
 1. **Handshake**: Inviato ogni 10 secondi per mantenere la Software Mode.
 2. **Polling Stato**: Ogni 100ms (ascolto passivo o timeout su Interfaccia 3).
-3. **Sincronizzazione LED**: Ogni 2 secondi. Inviare un singolo pacchetto che aggiorna tutti i LED in base all'ultimo stato rilevato.
+3. **Sincronizzazione LED**: Inviare subito quando cambia lo stato microfono, con un intervallo minimo anti-spam, e mantenere comunque un keepalive ogni 2 secondi. Evitare una logica basata solo sugli eventi mic: se un evento viene perso o la software mode decade, il colore resta desincronizzato.
 
 ## 1. Handshake (Software Mode)
 Inviare questi pacchetti all'Interfaccia 3:

--- a/HS80_FINDINGS.md
+++ b/HS80_FINDINGS.md
@@ -1,34 +1,32 @@
 # Corsair HS80 RGB Wireless (0x0A6B) - Linux HID Protocol
 
-## Device Info
-- **Vendor ID**: 0x1B1C
-- **Product ID**: 0x0A6B
-- **Primary Interface**: Interface 3 (Handles both RGB and Status)
+## Strategia di Stabilità (Verificata)
+Per evitare disconnessioni del dongle, la comunicazione deve seguire un ritmo costante e non eccessivo:
+1. **Handshake**: Inviato ogni 10 secondi per mantenere la Software Mode.
+2. **Polling Stato**: Ogni 100ms (ascolto passivo o timeout su Interfaccia 3).
+3. **Sincronizzazione LED**: Ogni 2 secondi. Inviare un singolo pacchetto che aggiorna tutti i LED in base all'ultimo stato rilevato.
 
 ## 1. Handshake (Software Mode)
-Send these to Interface 3 to enable custom control:
-1. `02 09 01 03 00 02` (Software Mode Enable)
-2. `02 09 0D 00 01` (Open Lighting Endpoint)
-
-*Note: Repeat these periodically (every 1-5s) to prevent the firmware from reverting to Hardware Mode.*
+Inviare questi pacchetti all'Interfaccia 3:
+- Enable Software Mode: `02 09 01 03 00 02`
+- Open Lighting Endpoint: `02 09 0D 00 01`
 
 ## 2. LED Control (Interleaved RGB)
 **Report ID**: 02, **Wireless Mode**: 09, **Command**: 06
 Format: `02 09 06 00 09 00 00 00 [R0 R1 R2] [G0 G1 G2] [B0 B1 B2]`
 
-### Verified Zone Mapping
+### Mappatura Zone Verificata
 - **Index 0**: Logo LED
 - **Index 1**: Power LED
 - **Index 2**: Microphone LED
 
-### Example: Power Green, Others Off
-- Rossi (0, 0, 0): `00 00 00`
-- Verdi (0, 255, 0): `00 FF 00`
-- Blu   (0, 0, 0): `00 00 00`
-**Full Packet**: `02 09 06 00 09 00 00 00 00 00 00 00 FF 00 00 00 00`
+### Esempio Stabile (Power Verde, Mic Dinamico)
+- Power: `R1=0, G1=255, B1=0`
+- Logo: `R0=0, G0=0, B0=0` (OFF)
+- Mic: `R2=255/0, G2=0, B2=0` (Rosso se mutato, OFF se attivo)
 
 ## 3. Status Monitoring (Mute/Battery)
-**Report ID**: 03
+**Report ID**: 03 (Interfaccia 3)
 **Event Code**: A6 (Microphone Status)
 - **Byte 6 (Index 5)**: `01` (Muted/Up), `00` (Active/Down)
 

--- a/main.cpp
+++ b/main.cpp
@@ -12,7 +12,7 @@
 #include <sstream>
 
 #define VENDOR_ID  0x1B1C
-#define PRODUCT_ID 0x0A73
+#define PRODUCT_ID 0x0A6B
 #define BATTERY_LEVEL_EVENT 0x0F
 #define CHARGING_EVENT 0x10
 #define POLL_INTERVAL_MS 200
@@ -113,6 +113,9 @@ public slots:
         // timer to keep track of how long ago we got the last msg
         QElapsedTimer lastMessageTimer;
         lastMessageTimer.start();
+        QElapsedTimer lastRequestTimer;
+        lastRequestTimer.start();
+        
         unsigned char buf[65] = {0};
         if(handle){
             wchar_t wstr[MAX_STR];
@@ -122,18 +125,37 @@ public slots:
             std::wcout << L"Product: " << wstr << std::endl;
             hid_get_serial_number_string(handle, wstr, MAX_STR);
             std::wcout << L"Serial Number: " << wstr << std::endl;
-
-            uint8_t req[65] = {0};
-            req[0] = 0x02;   // Report ID
-            req[1] = 0x08;   // Command group?
-            req[2] = 0x09;   // Subcommand: "get status" (inferred)
-            hid_write(handle, req, sizeof(req));  // or 64 on some backends
         }
+
+        auto sendRequest = [&]() {
+            if (!handle) return;
+            uint8_t req[65] = {0};
+            // Try different requests for HS80
+            req[0] = 0x08;
+            req[1] = 0x01; // Request battery/status
+            hid_write(handle, req, 65);
+            
+            req[0] = 0x02;
+            req[1] = 0x08;
+            req[2] = 0x09;
+            hid_write(handle, req, 65);
+            
+            if(g_verbose) qDebug() << "Status request sent";
+        };
+
+        sendRequest();
 
         while (true) {
             if(QThread::currentThread()->isInterruptionRequested()){
                 return;
             }
+
+            // Periodically request status if no updates received recently
+            if (lastRequestTimer.elapsed() > 5000) { // Every 5 seconds
+                sendRequest();
+                lastRequestTimer.restart();
+            }
+
             int res = hid_read_timeout(handle, buf, sizeof(buf), POLL_INTERVAL_MS);
             if (res > 0) {
                 lastMessageTimer.restart();
@@ -141,42 +163,54 @@ public slots:
                 QByteArray data(reinterpret_cast<const char*>(buf), res);
                 if(g_verbose) qDebug() << "Report ID" << QString::number(buf[0], 16)
                          << "response:" << data.toHex(' ');
-                double percentage;
-                bool charging;
-                switch (buf[3]) {
-                    case BATTERY_LEVEL_EVENT:
-                    {
-                        if (!connected){
-                            connected = true;
-                            if(g_switch_sink) switch_pipewire_sink(sink);
-                        }
-                        // only show tray icon if we have battery info
-                        emit trayActive();
-                        percentage = (buf[5] | (buf[6] << 8)) / 10;
-                        last_percentage = percentage;
-                        if(g_verbose) qDebug() << "Battery:" << percentage << "%";
-                    } break;
-                    case CHARGING_EVENT:
-                    {
-                        if (!connected){
-                            connected = true;
-                            if(g_switch_sink) switch_pipewire_sink(sink);
-                        }
-                        charging = (buf[5] == 1);
-                        last_charging = charging;
-                        if(g_verbose) qDebug() << "Charging: " << (charging ? "true" : "false");
-                    } break;
-                    default:
-                    {} break;
+                
+                double percentage = last_percentage;
+                bool charging = last_charging;
+                
+                uint8_t eventType = buf[3];
+                
+                if (eventType == BATTERY_LEVEL_EVENT) {
+                    double new_p = (buf[5] | (buf[6] << 8)) / 10.0;
+                    if (new_p > 0 && new_p <= 100) {
+                        percentage = new_p;
+                        if(g_verbose) qDebug() << "Battery Event - Percentage:" << percentage << "%";
+                    }
+                } else if (eventType == CHARGING_EVENT) {
+                    if(g_verbose) qDebug() << "Charging Event packet - Byte 5:" << buf[5];
+                    // On some HS80, 2 means 'Discharging/Full' while 1 means 'Charging'
+                    charging = (buf[5] == 1); 
+                    if(g_verbose) qDebug() << "Charging Event - State:" << (charging ? "Charging" : "Battery/Full");
+                } else if (buf[0] == 0x01 && res >= 5) {
+                    if (buf[2] == 0x09) { 
+                         double alt_p = (buf[4] | (buf[5] << 8)) / 10.0;
+                         if (alt_p > 0 && alt_p <= 100) {
+                             percentage = alt_p;
+                             if(g_verbose) qDebug() << "Found Battery in ID 1 - Percentage:" << percentage << "%";
+                         }
+                         if(g_verbose) qDebug() << "Status ID 1 - Byte 3 (State):" << buf[3];
+                    }
                 }
-                emit batteryUpdated(last_percentage, last_charging);
+
+                if (percentage != last_percentage || charging != last_charging || !connected) {
+                    if (!connected && (percentage > 0)) {
+                        connected = true;
+                        if(g_switch_sink) switch_pipewire_sink(sink);
+                        emit trayActive();
+                    }
+                    if (percentage > 0) last_percentage = percentage;
+                    last_charging = charging;
+                    emit batteryUpdated(last_percentage, last_charging);
+                }
             }
             else
             {
                 // No message received after timeout, assuming headset disconnected
                 if (lastMessageTimer.hasExpired(PASSIVE_TIMEOUT_MS)) {
-                    emit trayPassive();
-                    connected = false;
+                    if (connected) {
+                        emit trayPassive();
+                        connected = false;
+                        last_percentage = -1;
+                    }
                 }
             }
         }

--- a/main.cpp
+++ b/main.cpp
@@ -8,8 +8,11 @@
 #include <QMenu>
 #include <QIcon>
 #include <hidapi/hidapi.h>
+#include <array>
+#include <cstdint>
 #include <iostream>
 #include <sstream>
+#include <vector>
 
 #define VENDOR_ID  0x1B1C
 #define PRODUCT_ID 0x0A6B
@@ -17,12 +20,18 @@
 #define CHARGING_EVENT 0x10
 #define POLL_INTERVAL_MS 200
 #define MAX_STR 255
+#define REPORT_SIZE 65
+#define HEADSET_MODE_WIRELESS 0x09
 
 static bool g_verbose = false;
 static bool g_switch_sink = false;
 static int last_charging = false;
 static double last_percentage = -1;
 static const int PASSIVE_TIMEOUT_MS = 30 * 60 * 1000;
+static const int INITIAL_BATTERY_REQUEST_DELAY_MS = 1000;
+static const int UNKNOWN_BATTERY_REQUEST_INTERVAL_MS = 2000;
+static const int BATTERY_REQUEST_INTERVAL_MS = 60 * 1000;
+static const int STATUS_REQUEST_INTERVAL_MS = 10 * 1000;
 static QString sink;
 
 struct Sink {
@@ -102,7 +111,7 @@ public slots:
         bool connected = false;
         handle = nullptr;
         while (!handle && !QThread::currentThread()->isInterruptionRequested()) {
-            handle = hid_open(VENDOR_ID, PRODUCT_ID, nullptr);
+            handle = openHs80Interface();
             if (!handle) {
                 std::wcout << L"Unable to open HID device, retrying in 30 seconds..." << std::endl;
                 std::wcout << L"Is the Wireless Receiver connected?" << std::endl;
@@ -113,10 +122,12 @@ public slots:
         // timer to keep track of how long ago we got the last msg
         QElapsedTimer lastMessageTimer;
         lastMessageTimer.start();
-        QElapsedTimer lastRequestTimer;
-        lastRequestTimer.start();
+        QElapsedTimer lastBatteryRequestTimer;
+        lastBatteryRequestTimer.start();
+        QElapsedTimer lastStatusRequestTimer;
+        lastStatusRequestTimer.start();
         
-        unsigned char buf[65] = {0};
+        unsigned char buf[REPORT_SIZE] = {0};
         if(handle){
             wchar_t wstr[MAX_STR];
             hid_get_manufacturer_string(handle, wstr, MAX_STR);
@@ -127,33 +138,25 @@ public slots:
             std::wcout << L"Serial Number: " << wstr << std::endl;
         }
 
-        auto sendRequest = [&]() {
-            if (!handle) return;
-            uint8_t req[65] = {0};
-            // Try different requests for HS80
-            req[0] = 0x08;
-            req[1] = 0x01; // Request battery/status
-            hid_write(handle, req, 65);
-            
-            req[0] = 0x02;
-            req[1] = 0x08;
-            req[2] = 0x09;
-            hid_write(handle, req, 65);
-            
-            if(g_verbose) qDebug() << "Status request sent";
-        };
-
-        sendRequest();
+        QThread::msleep(INITIAL_BATTERY_REQUEST_DELAY_MS);
+        requestBattery();
 
         while (true) {
             if(QThread::currentThread()->isInterruptionRequested()){
                 return;
             }
 
-            // Periodically request status if no updates received recently
-            if (lastRequestTimer.elapsed() > 5000) { // Every 5 seconds
-                sendRequest();
-                lastRequestTimer.restart();
+            if (lastStatusRequestTimer.elapsed() > STATUS_REQUEST_INTERVAL_MS) {
+                requestSleepStatus();
+                lastStatusRequestTimer.restart();
+            }
+
+            int batteryRequestInterval = last_percentage > 0
+                                             ? BATTERY_REQUEST_INTERVAL_MS
+                                             : UNKNOWN_BATTERY_REQUEST_INTERVAL_MS;
+            if (lastBatteryRequestTimer.elapsed() > batteryRequestInterval) {
+                requestBattery();
+                lastBatteryRequestTimer.restart();
             }
 
             int res = hid_read_timeout(handle, buf, sizeof(buf), POLL_INTERVAL_MS);
@@ -170,21 +173,22 @@ public slots:
                 uint8_t eventType = buf[3];
                 
                 if (eventType == BATTERY_LEVEL_EVENT) {
-                    double new_p = (buf[5] | (buf[6] << 8)) / 10.0;
+                    double new_p = readBatteryPercentage(buf, res);
                     if (new_p > 0 && new_p <= 100) {
                         percentage = new_p;
                         if(g_verbose) qDebug() << "Battery Event - Percentage:" << percentage << "%";
                     }
                 } else if (eventType == CHARGING_EVENT) {
-                    // Only update charging status, keep the percentage we already have
-                    charging = (buf[5] == 1); 
+                    charging = parseChargingState(buf, res);
                     if(g_verbose) qDebug() << "Charging Event - State:" << (charging ? "Charging" : "Battery/Full");
-                } else if (buf[0] == 0x01 && res >= 5) {
-                    if (buf[2] == 0x09) { 
-                         double alt_p = (buf[4] | (buf[5] << 8)) / 10.0;
-                         if (alt_p > 0 && alt_p <= 100) {
-                             percentage = alt_p;
-                         }
+                } else if (isQueryResponse(buf, res)) {
+                    double responsePercentage = readQueryResponseBatteryPercentage(buf, res);
+                    if (responsePercentage > 0) {
+                        percentage = responsePercentage;
+                        if(g_verbose) qDebug() << "Battery Response - Percentage:" << percentage << "%";
+                    } else if (isQueryResponseChargingState(buf, res)) {
+                        charging = parseChargingState(buf, res);
+                        if(g_verbose) qDebug() << "Charging Response - State:" << (charging ? "Charging" : "Battery/Full");
                     }
                 }
 
@@ -215,6 +219,99 @@ public slots:
 
 private:
     hid_device* handle = nullptr;
+
+    hid_device* openHs80Interface() {
+        hid_device_info* devs = hid_enumerate(VENDOR_ID, PRODUCT_ID);
+        hid_device_info* curDev = devs;
+        hid_device* opened = nullptr;
+
+        while (curDev) {
+            if (curDev->interface_number == 3) {
+                opened = hid_open_path(curDev->path);
+                if (opened) break;
+            }
+            curDev = curDev->next;
+        }
+
+        hid_free_enumeration(devs);
+        return opened;
+    }
+
+    void writePacket(const std::vector<uint8_t>& packet) {
+        if (!handle) return;
+
+        uint8_t buf[REPORT_SIZE] = {0};
+        for (size_t i = 0; i < packet.size() && i < REPORT_SIZE; ++i) {
+            buf[i] = packet[i];
+        }
+
+        int res = hid_write(handle, buf, sizeof(buf));
+        if(g_verbose && res < 0) qDebug() << "hid_write failed";
+    }
+
+    void drainReadBuffer() {
+        if (!handle) return;
+
+        uint8_t buf[REPORT_SIZE] = {0};
+        while (hid_read_timeout(handle, buf, sizeof(buf), 0) > 0) {}
+    }
+
+    void requestBattery() {
+        drainReadBuffer();
+        writePacket({0x02, HEADSET_MODE_WIRELESS, 0x02, BATTERY_LEVEL_EVENT, 0x00});
+        QThread::msleep(50);
+        writePacket({0x02, HEADSET_MODE_WIRELESS, 0x02, CHARGING_EVENT, 0x00});
+        if(g_verbose) qDebug() << "Battery request sent";
+    }
+
+    void requestSleepStatus() {
+        writePacket({0x02, HEADSET_MODE_WIRELESS, 0x02, CHARGING_EVENT, 0x00});
+    }
+
+    double readBatteryPercentage(const uint8_t* buf, int res) {
+        if (res > 6) {
+            double eventValue = (buf[5] | (buf[6] << 8)) / 10.0;
+            if (eventValue > 0 && eventValue <= 100) return eventValue;
+        }
+
+        if (res > 5) {
+            double responseValue = (buf[4] | (buf[5] << 8)) / 10.0;
+            if (responseValue > 0 && responseValue <= 100) return responseValue;
+        }
+
+        return -1;
+    }
+
+    bool isQueryResponse(const uint8_t* buf, int res) {
+        return res > 5 && buf[0] == 0x01 && buf[1] == 0x01 && buf[2] == 0x02 && buf[3] == 0x00;
+    }
+
+    double readQueryResponseBatteryPercentage(const uint8_t* buf, int res) {
+        if (!isQueryResponse(buf, res)) return -1;
+
+        int rawValue = buf[4] | (buf[5] << 8);
+        if (rawValue > 100 && rawValue <= 1000) {
+            return rawValue / 10.0;
+        }
+
+        return -1;
+    }
+
+    bool isQueryResponseChargingState(const uint8_t* buf, int res) {
+        return isQueryResponse(buf, res) && buf[4] >= 1 && buf[4] <= 3 && buf[5] == 0;
+    }
+
+    bool parseChargingState(const uint8_t* buf, int res) {
+        uint8_t state = 0;
+        if (res > 5 && buf[5] >= 1 && buf[5] <= 3) {
+            state = buf[5];
+        } else if (res > 4) {
+            state = buf[4];
+        }
+
+        return state == 1;
+    }
+
 };
 
 QIcon getBatteryIcon(double percentage, bool charging) {
@@ -351,4 +448,3 @@ int main(int argc, char* argv[]) {
 }
 
 #include "main.moc"
-

--- a/main.cpp
+++ b/main.cpp
@@ -176,8 +176,7 @@ public slots:
                         if(g_verbose) qDebug() << "Battery Event - Percentage:" << percentage << "%";
                     }
                 } else if (eventType == CHARGING_EVENT) {
-                    if(g_verbose) qDebug() << "Charging Event packet - Byte 5:" << buf[5];
-                    // On some HS80, 2 means 'Discharging/Full' while 1 means 'Charging'
+                    // Only update charging status, keep the percentage we already have
                     charging = (buf[5] == 1); 
                     if(g_verbose) qDebug() << "Charging Event - State:" << (charging ? "Charging" : "Battery/Full");
                 } else if (buf[0] == 0x01 && res >= 5) {
@@ -185,9 +184,7 @@ public slots:
                          double alt_p = (buf[4] | (buf[5] << 8)) / 10.0;
                          if (alt_p > 0 && alt_p <= 100) {
                              percentage = alt_p;
-                             if(g_verbose) qDebug() << "Found Battery in ID 1 - Percentage:" << percentage << "%";
                          }
-                         if(g_verbose) qDebug() << "Status ID 1 - Byte 3 (State):" << buf[3];
                     }
                 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -10,6 +10,7 @@
 #include <hidapi/hidapi.h>
 #include <array>
 #include <cstdint>
+#include <deque>
 #include <iostream>
 #include <sstream>
 #include <vector>
@@ -18,6 +19,7 @@
 #define PRODUCT_ID 0x0A6B
 #define BATTERY_LEVEL_EVENT 0x0F
 #define CHARGING_EVENT 0x10
+#define MIC_STATUS_EVENT 0xA6
 #define POLL_INTERVAL_MS 200
 #define MAX_STR 255
 #define REPORT_SIZE 65
@@ -31,7 +33,12 @@ static const int PASSIVE_TIMEOUT_MS = 30 * 60 * 1000;
 static const int INITIAL_BATTERY_REQUEST_DELAY_MS = 1000;
 static const int UNKNOWN_BATTERY_REQUEST_INTERVAL_MS = 2000;
 static const int BATTERY_REQUEST_INTERVAL_MS = 60 * 1000;
+static const int MIC_REQUEST_INTERVAL_MS = 1000;
 static const int STATUS_REQUEST_INTERVAL_MS = 10 * 1000;
+static const int LIGHTING_HANDSHAKE_INTERVAL_MS = 10 * 1000;
+static const int LED_KEEPALIVE_INTERVAL_MS = 2 * 1000;
+static const int LED_MIN_UPDATE_INTERVAL_MS = 250;
+static const int HEADSET_RESPONSE_TIMEOUT_MS = 3000;
 static QString sink;
 
 struct Sink {
@@ -109,6 +116,10 @@ public slots:
     void startPolling() {
         hid_init();
         bool connected = false;
+        bool headsetResponding = true;
+        bool micMuted = false;
+        bool ledDirty = true;
+        bool lightingDirty = true;
         handle = nullptr;
         while (!handle && !QThread::currentThread()->isInterruptionRequested()) {
             handle = openHs80Interface();
@@ -124,8 +135,14 @@ public slots:
         lastMessageTimer.start();
         QElapsedTimer lastBatteryRequestTimer;
         lastBatteryRequestTimer.start();
+        QElapsedTimer lastMicRequestTimer;
+        lastMicRequestTimer.start();
         QElapsedTimer lastStatusRequestTimer;
         lastStatusRequestTimer.start();
+        QElapsedTimer lastLightingTimer;
+        lastLightingTimer.start();
+        QElapsedTimer lastLedTimer;
+        lastLedTimer.start();
         
         unsigned char buf[REPORT_SIZE] = {0};
         if(handle){
@@ -139,11 +156,27 @@ public slots:
         }
 
         QThread::msleep(INITIAL_BATTERY_REQUEST_DELAY_MS);
+        configureLighting();
+        sendLedState(micMuted);
+        lightingDirty = false;
+        ledDirty = false;
+        lastLightingTimer.restart();
+        lastLedTimer.restart();
         requestBattery();
+        requestMicStatus();
 
         while (true) {
             if(QThread::currentThread()->isInterruptionRequested()){
                 return;
+            }
+
+            if (lastLightingTimer.elapsed() > LIGHTING_HANDSHAKE_INTERVAL_MS) {
+                lightingDirty = true;
+            }
+
+            if (lastMicRequestTimer.elapsed() > MIC_REQUEST_INTERVAL_MS) {
+                requestMicStatus();
+                lastMicRequestTimer.restart();
             }
 
             if (lastStatusRequestTimer.elapsed() > STATUS_REQUEST_INTERVAL_MS) {
@@ -159,8 +192,29 @@ public slots:
                 lastBatteryRequestTimer.restart();
             }
 
+            bool ledKeepaliveDue = lastLedTimer.elapsed() > LED_KEEPALIVE_INTERVAL_MS;
+            bool ledChangeDue = (ledDirty || lightingDirty) && lastLedTimer.elapsed() > LED_MIN_UPDATE_INTERVAL_MS;
+            if (ledKeepaliveDue || ledChangeDue) {
+                if (lightingDirty) {
+                    configureLighting();
+                    lightingDirty = false;
+                    lastLightingTimer.restart();
+                }
+                sendLedState(micMuted);
+                ledDirty = false;
+                lastLedTimer.restart();
+            }
+
             int res = hid_read_timeout(handle, buf, sizeof(buf), POLL_INTERVAL_MS);
             if (res > 0) {
+                bool refreshAfterResponse = false;
+                if (!headsetResponding) {
+                    lightingDirty = true;
+                    ledDirty = true;
+                    refreshAfterResponse = true;
+                    if(g_verbose) qDebug() << "Headset response restored, lighting resync queued";
+                }
+                headsetResponding = true;
                 lastMessageTimer.restart();
 
                 QByteArray data(reinterpret_cast<const char*>(buf), res);
@@ -181,12 +235,30 @@ public slots:
                 } else if (eventType == CHARGING_EVENT) {
                     charging = parseChargingState(buf, res);
                     if(g_verbose) qDebug() << "Charging Event - State:" << (charging ? "Charging" : "Battery/Full");
+                } else if (eventType == MIC_STATUS_EVENT) {
+                    bool newMicMuted = parseMicMuted(buf, res);
+                    if (newMicMuted != micMuted) {
+                        micMuted = newMicMuted;
+                        ledDirty = true;
+                    }
+                    if(g_verbose) qDebug() << "Mic Event - State:" << (micMuted ? "Muted" : "Active");
                 } else if (isQueryResponse(buf, res)) {
                     double responsePercentage = readQueryResponseBatteryPercentage(buf, res);
                     if (responsePercentage > 0) {
+                        discardPendingQuery(QueryKind::BatteryLevel);
                         percentage = responsePercentage;
                         if(g_verbose) qDebug() << "Battery Response - Percentage:" << percentage << "%";
+                    } else if (isQueryResponseMicState(buf, res) && peekPendingQuery() == QueryKind::MicStatus) {
+                        takePendingQuery();
+                        bool newMicMuted = parseMicMuted(buf, res);
+                        if (newMicMuted != micMuted) {
+                            micMuted = newMicMuted;
+                            ledDirty = true;
+                        }
+                        if(g_verbose) qDebug() << "Mic Response - State:" << (micMuted ? "Muted" : "Active");
                     } else if (isQueryResponseChargingState(buf, res)) {
+                        discardPendingQuery(QueryKind::BatteryStatus);
+                        discardPendingQuery(QueryKind::SleepStatus);
                         charging = parseChargingState(buf, res);
                         if(g_verbose) qDebug() << "Charging Response - State:" << (charging ? "Charging" : "Battery/Full");
                     }
@@ -202,9 +274,18 @@ public slots:
                     last_charging = charging;
                     emit batteryUpdated(last_percentage, last_charging);
                 }
+
+                if (refreshAfterResponse) {
+                    requestBattery();
+                    requestMicStatus();
+                }
             }
             else
             {
+                if (lastMessageTimer.hasExpired(HEADSET_RESPONSE_TIMEOUT_MS)) {
+                    headsetResponding = false;
+                }
+
                 // No message received after timeout, assuming headset disconnected
                 if (lastMessageTimer.hasExpired(PASSIVE_TIMEOUT_MS)) {
                     if (connected) {
@@ -218,7 +299,16 @@ public slots:
     }
 
 private:
+    enum class QueryKind {
+        None,
+        BatteryLevel,
+        BatteryStatus,
+        SleepStatus,
+        MicStatus,
+    };
+
     hid_device* handle = nullptr;
+    std::deque<QueryKind> pendingQueries;
 
     hid_device* openHs80Interface() {
         hid_device_info* devs = hid_enumerate(VENDOR_ID, PRODUCT_ID);
@@ -254,18 +344,72 @@ private:
 
         uint8_t buf[REPORT_SIZE] = {0};
         while (hid_read_timeout(handle, buf, sizeof(buf), 0) > 0) {}
+        pendingQueries.clear();
+    }
+
+    void writeQuery(const std::vector<uint8_t>& packet, QueryKind kind) {
+        writePacket(packet);
+        pendingQueries.push_back(kind);
+    }
+
+    QueryKind takePendingQuery() {
+        if (pendingQueries.empty()) return QueryKind::None;
+
+        QueryKind kind = pendingQueries.front();
+        pendingQueries.pop_front();
+        return kind;
+    }
+
+    QueryKind peekPendingQuery() const {
+        if (pendingQueries.empty()) return QueryKind::None;
+
+        return pendingQueries.front();
+    }
+
+    void discardPendingQuery(QueryKind kind) {
+        for (auto it = pendingQueries.begin(); it != pendingQueries.end(); ++it) {
+            if (*it == kind) {
+                pendingQueries.erase(it);
+                return;
+            }
+        }
+    }
+
+    void configureLighting() {
+        writePacket({0x02, HEADSET_MODE_WIRELESS, 0x01, 0x03, 0x00, 0x02});
+        writePacket({0x02, HEADSET_MODE_WIRELESS, 0x0D, 0x00, 0x01});
+        if(g_verbose) qDebug() << "Lighting endpoint configured";
     }
 
     void requestBattery() {
         drainReadBuffer();
-        writePacket({0x02, HEADSET_MODE_WIRELESS, 0x02, BATTERY_LEVEL_EVENT, 0x00});
+        writeQuery({0x02, HEADSET_MODE_WIRELESS, 0x02, BATTERY_LEVEL_EVENT, 0x00}, QueryKind::BatteryLevel);
         QThread::msleep(50);
-        writePacket({0x02, HEADSET_MODE_WIRELESS, 0x02, CHARGING_EVENT, 0x00});
+        writeQuery({0x02, HEADSET_MODE_WIRELESS, 0x02, CHARGING_EVENT, 0x00}, QueryKind::BatteryStatus);
         if(g_verbose) qDebug() << "Battery request sent";
     }
 
+    void requestMicStatus() {
+        writeQuery({0x02, HEADSET_MODE_WIRELESS, 0x02, MIC_STATUS_EVENT, 0x00}, QueryKind::MicStatus);
+        if(g_verbose) qDebug() << "Mic status request sent";
+    }
+
     void requestSleepStatus() {
-        writePacket({0x02, HEADSET_MODE_WIRELESS, 0x02, CHARGING_EVENT, 0x00});
+        writeQuery({0x02, HEADSET_MODE_WIRELESS, 0x02, CHARGING_EVENT, 0x00}, QueryKind::SleepStatus);
+    }
+
+    void sendLedState(bool micMuted) {
+        uint8_t buf[REPORT_SIZE] = {0};
+        buf[0] = 0x02;
+        buf[1] = HEADSET_MODE_WIRELESS;
+        buf[2] = 0x06;
+        buf[3] = 0x00;
+        buf[4] = 0x09;
+        buf[10] = micMuted ? 255 : 0;
+        buf[12] = 255;
+
+        if (handle) hid_write(handle, buf, sizeof(buf));
+        if(g_verbose) qDebug() << "LED state sent:" << (micMuted ? "muted" : "active");
     }
 
     double readBatteryPercentage(const uint8_t* buf, int res) {
@@ -301,6 +445,10 @@ private:
         return isQueryResponse(buf, res) && buf[4] >= 1 && buf[4] <= 3 && buf[5] == 0;
     }
 
+    bool isQueryResponseMicState(const uint8_t* buf, int res) {
+        return isQueryResponse(buf, res) && (buf[4] == 0 || buf[4] == 1) && buf[5] == 0;
+    }
+
     bool parseChargingState(const uint8_t* buf, int res) {
         uint8_t state = 0;
         if (res > 5 && buf[5] >= 1 && buf[5] <= 3) {
@@ -310,6 +458,22 @@ private:
         }
 
         return state == 1;
+    }
+
+    bool parseMicMuted(const uint8_t* buf, int res) {
+        if (isQueryResponse(buf, res) && res > 4) {
+            return buf[4] == 1;
+        }
+
+        if (res > 5 && (buf[5] == 0 || buf[5] == 1)) {
+            return buf[5] == 1;
+        }
+
+        if (res > 4) {
+            return buf[4] == 1;
+        }
+
+        return false;
     }
 
 };

--- a/main.cpp
+++ b/main.cpp
@@ -1,16 +1,26 @@
 #include <KStatusNotifierItem>
 #include <QApplication>
-#include <QThread>
-#include <QPainter>
-#include <QPainterPath>
+#include <QCloseEvent>
+#include <QColorDialog>
+#include <QComboBox>
 #include <QElapsedTimer>
+#include <QFormLayout>
+#include <QIcon>
 #include <QLoggingCategory>
 #include <QMenu>
-#include <QIcon>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPushButton>
+#include <QSettings>
+#include <QThread>
+#include <QVBoxLayout>
 #include <hidapi/hidapi.h>
 #include <array>
 #include <cstdint>
 #include <deque>
+#include <functional>
 #include <iostream>
 #include <sstream>
 #include <vector>
@@ -44,6 +54,178 @@ static QString sink;
 struct Sink {
     std::string id;
     std::string name;
+};
+
+struct LedConfig {
+    QColor logoColor;
+    QColor powerColor;
+    QColor micMutedColor;
+    QColor micUnmutedColor;
+};
+
+Q_DECLARE_METATYPE(LedConfig)
+
+static LedConfig defaultLedConfig() {
+    return {
+        QColor(0, 0, 0),
+        QColor(0, 255, 0),
+        QColor(255, 0, 0),
+        QColor(0, 0, 0),
+    };
+}
+
+static QColor readSettingColor(QSettings& settings, const char* key, const QColor& fallback) {
+    if (!settings.contains(key)) return fallback;
+
+    const QVariant value = settings.value(key);
+    QColor color = value.value<QColor>();
+    if (!color.isValid()) color = QColor(value.toString());
+    return color.isValid() ? color : fallback;
+}
+
+static QColor normalizeMicColor(const QColor& color, const QColor& fallback) {
+    const QRgb rgb = color.rgb();
+    if (rgb == QColor(0, 0, 0).rgb()
+        || rgb == QColor(255, 0, 0).rgb()
+        || rgb == QColor(255, 255, 255).rgb()) {
+        return color;
+    }
+    return fallback;
+}
+
+static LedConfig loadLedConfig() {
+    QSettings settings;
+    const LedConfig defaults = defaultLedConfig();
+    return {
+        readSettingColor(settings, "logoColor", defaults.logoColor),
+        readSettingColor(settings, "powerColor", defaults.powerColor),
+        normalizeMicColor(readSettingColor(settings, "micMutedColor", defaults.micMutedColor), defaults.micMutedColor),
+        normalizeMicColor(readSettingColor(settings, "micUnmutedColor", defaults.micUnmutedColor), defaults.micUnmutedColor),
+    };
+}
+
+static void saveLedConfig(const LedConfig& config) {
+    QSettings settings;
+    settings.setValue("logoColor", config.logoColor);
+    settings.setValue("powerColor", config.powerColor);
+    settings.setValue("micMutedColor", config.micMutedColor);
+    settings.setValue("micUnmutedColor", config.micUnmutedColor);
+}
+
+class LedSettingsWindow : public QWidget {
+    Q_OBJECT
+public:
+    explicit LedSettingsWindow(const LedConfig& initialConfig, QWidget* parent = nullptr)
+        : QWidget(parent), config(initialConfig) {
+        setWindowTitle("HS80 LED");
+        setWindowIcon(QIcon::fromTheme("preferences-desktop-display"));
+
+        auto* layout = new QVBoxLayout(this);
+        auto* form = new QFormLayout();
+        layout->addLayout(form);
+
+        powerButton = createColorButton(config.powerColor);
+        logoButton = createColorButton(config.logoColor);
+        form->addRow("Power LED", powerButton);
+        form->addRow("Logo LED", logoButton);
+
+        micMutedCombo = createMicCombo(config.micMutedColor, QColor(255, 0, 0));
+        micUnmutedCombo = createMicCombo(config.micUnmutedColor, QColor(0, 0, 0));
+        form->addRow("Mic muted", micMutedCombo);
+        form->addRow("Mic unmuted", micUnmutedCombo);
+
+        connect(powerButton, &QPushButton::clicked, this, [this]() {
+            chooseColor("Power LED", config.powerColor, [this](const QColor& color) {
+                config.powerColor = color;
+                updateColorButton(powerButton, color);
+            });
+        });
+
+        connect(logoButton, &QPushButton::clicked, this, [this]() {
+            chooseColor("Logo LED", config.logoColor, [this](const QColor& color) {
+                config.logoColor = color;
+                updateColorButton(logoButton, color);
+            });
+        });
+
+        connect(micMutedCombo, &QComboBox::currentIndexChanged, this, [this](int) {
+            config.micMutedColor = micColorFromCombo(micMutedCombo);
+            persistAndNotify();
+        });
+
+        connect(micUnmutedCombo, &QComboBox::currentIndexChanged, this, [this](int) {
+            config.micUnmutedColor = micColorFromCombo(micUnmutedCombo);
+            persistAndNotify();
+        });
+
+        setMinimumWidth(320);
+    }
+
+signals:
+    void ledConfigChanged(const LedConfig& config);
+
+protected:
+    void closeEvent(QCloseEvent* event) override {
+        hide();
+        event->ignore();
+    }
+
+private:
+    LedConfig config;
+    QPushButton* powerButton = nullptr;
+    QPushButton* logoButton = nullptr;
+    QComboBox* micMutedCombo = nullptr;
+    QComboBox* micUnmutedCombo = nullptr;
+
+    QPushButton* createColorButton(const QColor& color) {
+        auto* button = new QPushButton(this);
+        button->setMinimumWidth(120);
+        updateColorButton(button, color);
+        return button;
+    }
+
+    void updateColorButton(QPushButton* button, const QColor& color) {
+        button->setText(color.name(QColor::HexRgb).toUpper());
+        button->setStyleSheet(QString(
+            "QPushButton { background-color: %1; color: %2; border: 1px solid palette(mid); padding: 6px 10px; }")
+                                  .arg(color.name(QColor::HexRgb),
+                                       color.lightness() < 128 ? "#ffffff" : "#000000"));
+    }
+
+    void chooseColor(const QString& title, const QColor& currentColor, const std::function<void(const QColor&)>& applyColor) {
+        const QColor color = QColorDialog::getColor(currentColor, this, title);
+        if (!color.isValid()) return;
+
+        applyColor(color);
+        persistAndNotify();
+    }
+
+    QComboBox* createMicCombo(const QColor& color, const QColor& fallback) {
+        auto* combo = new QComboBox(this);
+        combo->addItem("Spento", QColor(0, 0, 0));
+        combo->addItem("Rosso", QColor(255, 0, 0));
+        combo->addItem("Bianco", QColor(255, 255, 255));
+
+        const int index = comboIndexForColor(combo, color);
+        combo->setCurrentIndex(index >= 0 ? index : comboIndexForColor(combo, fallback));
+        return combo;
+    }
+
+    int comboIndexForColor(const QComboBox* combo, const QColor& color) const {
+        for (int i = 0; i < combo->count(); ++i) {
+            if (combo->itemData(i).value<QColor>().rgb() == color.rgb()) return i;
+        }
+        return -1;
+    }
+
+    QColor micColorFromCombo(const QComboBox* combo) const {
+        return combo->currentData().value<QColor>();
+    }
+
+    void persistAndNotify() {
+        saveLedConfig(config);
+        emit ledConfigChanged(config);
+    }
 };
 
 std::vector<Sink> get_sinks() {
@@ -113,12 +295,17 @@ signals:
     void trayActive();
 
 public slots:
+    void updateLedConfig(const LedConfig& config) {
+        QMutexLocker locker(&ledConfigMutex);
+        ledConfig = config;
+        ledDirty = true;
+    }
+
     void startPolling() {
         hid_init();
         bool connected = false;
         bool headsetResponding = true;
         bool micMuted = false;
-        bool ledDirty = true;
         bool lightingDirty = true;
         handle = nullptr;
         while (!handle && !QThread::currentThread()->isInterruptionRequested()) {
@@ -157,9 +344,9 @@ public slots:
 
         QThread::msleep(INITIAL_BATTERY_REQUEST_DELAY_MS);
         configureLighting();
+        clearLedDirty();
         sendLedState(micMuted);
         lightingDirty = false;
-        ledDirty = false;
         lastLightingTimer.restart();
         lastLedTimer.restart();
         requestBattery();
@@ -193,15 +380,15 @@ public slots:
             }
 
             bool ledKeepaliveDue = lastLedTimer.elapsed() > LED_KEEPALIVE_INTERVAL_MS;
-            bool ledChangeDue = (ledDirty || lightingDirty) && lastLedTimer.elapsed() > LED_MIN_UPDATE_INTERVAL_MS;
+            bool ledChangeDue = (isLedDirty() || lightingDirty) && lastLedTimer.elapsed() > LED_MIN_UPDATE_INTERVAL_MS;
             if (ledKeepaliveDue || ledChangeDue) {
                 if (lightingDirty) {
                     configureLighting();
                     lightingDirty = false;
                     lastLightingTimer.restart();
                 }
+                clearLedDirty();
                 sendLedState(micMuted);
-                ledDirty = false;
                 lastLedTimer.restart();
             }
 
@@ -210,7 +397,7 @@ public slots:
                 bool refreshAfterResponse = false;
                 if (!headsetResponding) {
                     lightingDirty = true;
-                    ledDirty = true;
+                    markLedDirty();
                     refreshAfterResponse = true;
                     if(g_verbose) qDebug() << "Headset response restored, lighting resync queued";
                 }
@@ -239,7 +426,7 @@ public slots:
                     bool newMicMuted = parseMicMuted(buf, res);
                     if (newMicMuted != micMuted) {
                         micMuted = newMicMuted;
-                        ledDirty = true;
+                        markLedDirty();
                     }
                     if(g_verbose) qDebug() << "Mic Event - State:" << (micMuted ? "Muted" : "Active");
                 } else if (isQueryResponse(buf, res)) {
@@ -253,7 +440,7 @@ public slots:
                         bool newMicMuted = parseMicMuted(buf, res);
                         if (newMicMuted != micMuted) {
                             micMuted = newMicMuted;
-                            ledDirty = true;
+                            markLedDirty();
                         }
                         if(g_verbose) qDebug() << "Mic Response - State:" << (micMuted ? "Muted" : "Active");
                     } else if (isQueryResponseChargingState(buf, res)) {
@@ -309,6 +496,29 @@ private:
 
     hid_device* handle = nullptr;
     std::deque<QueryKind> pendingQueries;
+    QMutex ledConfigMutex;
+    LedConfig ledConfig = defaultLedConfig();
+    bool ledDirty = true;
+
+    bool isLedDirty() {
+        QMutexLocker locker(&ledConfigMutex);
+        return ledDirty;
+    }
+
+    void markLedDirty() {
+        QMutexLocker locker(&ledConfigMutex);
+        ledDirty = true;
+    }
+
+    void clearLedDirty() {
+        QMutexLocker locker(&ledConfigMutex);
+        ledDirty = false;
+    }
+
+    LedConfig currentLedConfig() {
+        QMutexLocker locker(&ledConfigMutex);
+        return ledConfig;
+    }
 
     hid_device* openHs80Interface() {
         hid_device_info* devs = hid_enumerate(VENDOR_ID, PRODUCT_ID);
@@ -399,14 +609,24 @@ private:
     }
 
     void sendLedState(bool micMuted) {
+        const LedConfig config = currentLedConfig();
+        const QColor micColor = micMuted ? config.micMutedColor : config.micUnmutedColor;
+
         uint8_t buf[REPORT_SIZE] = {0};
         buf[0] = 0x02;
         buf[1] = HEADSET_MODE_WIRELESS;
         buf[2] = 0x06;
         buf[3] = 0x00;
         buf[4] = 0x09;
-        buf[10] = micMuted ? 255 : 0;
-        buf[12] = 255;
+        buf[8] = static_cast<uint8_t>(config.logoColor.red());
+        buf[9] = static_cast<uint8_t>(config.powerColor.red());
+        buf[10] = static_cast<uint8_t>(micColor.red());
+        buf[11] = static_cast<uint8_t>(config.logoColor.green());
+        buf[12] = static_cast<uint8_t>(config.powerColor.green());
+        buf[13] = static_cast<uint8_t>(micColor.green());
+        buf[14] = static_cast<uint8_t>(config.logoColor.blue());
+        buf[15] = static_cast<uint8_t>(config.powerColor.blue());
+        buf[16] = static_cast<uint8_t>(micColor.blue());
 
         if (handle) hid_write(handle, buf, sizeof(buf));
         if(g_verbose) qDebug() << "LED state sent:" << (micMuted ? "muted" : "active");
@@ -521,6 +741,11 @@ QIcon getBatteryIcon(double percentage, bool charging) {
 
 int main(int argc, char* argv[]) {
     QApplication app(argc, argv);
+    QApplication::setOrganizationName("hs80tray");
+    QApplication::setApplicationName("hs80tray");
+    app.setQuitOnLastWindowClosed(false);
+    qRegisterMetaType<LedConfig>("LedConfig");
+
     QStringList args = app.arguments();
     for (int i = 1; i < args.size(); ++i) {
         if (args[i] == "-h" || args[i] == "--help") {
@@ -565,12 +790,26 @@ int main(int argc, char* argv[]) {
     menu->addSeparator();
     tray.setContextMenu(menu);
 
+    const LedConfig initialLedConfig = loadLedConfig();
+    LedSettingsWindow ledSettingsWindow(initialLedConfig);
+    QObject::connect(&tray, &KStatusNotifierItem::activateRequested,
+                     &app,
+                     [&ledSettingsWindow](bool, const QPoint&) {
+        ledSettingsWindow.show();
+        ledSettingsWindow.raise();
+        ledSettingsWindow.activateWindow();
+    });
+
     // Worker thread for HID polling
     QThread *workerThread = new QThread();
     HIDWorker* worker = new HIDWorker;
+    worker->updateLedConfig(initialLedConfig);
     worker->moveToThread(workerThread);
 
     QObject::connect(workerThread, &QThread::started, worker, &HIDWorker::startPolling);
+    QObject::connect(&ledSettingsWindow, &LedSettingsWindow::ledConfigChanged,
+                     worker, &HIDWorker::updateLedConfig,
+                     Qt::DirectConnection);
     QObject::connect(worker, &HIDWorker::batteryUpdated,
                      &app,
                      [&tray, batteryAction, chargingAction](double percentage, bool charging){

--- a/test_leds.cpp
+++ b/test_leds.cpp
@@ -31,26 +31,45 @@ int main() {
 
     if (!h) return 1;
 
-    std::cout << "BASELINE STABILE: Power Verde, Logo Off, Mic Off." << std::endl;
+    std::cout << "--- STEP 2.8: SYNC TOTALE (STABILE + DINAMICO) ---" << std::endl;
 
-    int count = 0;
+    unsigned char read_buf[65];
+    bool mic_muted = false;
+    auto last_led_time = std::chrono::steady_clock::now();
+    auto last_handshake_time = std::chrono::steady_clock::now();
+
     while (true) {
-        if (count % 5 == 0) {
+        auto now = std::chrono::steady_clock::now();
+
+        // 1. Handshake ogni 10 secondi
+        if (std::chrono::duration_cast<std::chrono::seconds>(now - last_handshake_time).count() >= 10) {
             send_cmd(h, {0x01, 0x03, 0x00, 0x02});
             send_cmd(h, {0x0D, 0x00, 0x01});
+            last_handshake_time = now;
         }
 
-        unsigned char led_pkt[65] = {0};
-        led_pkt[0] = 0x02; led_pkt[1] = 0x09; led_pkt[2] = 0x06; led_pkt[3] = 0x00;
-        led_pkt[4] = 0x09; 
-        
-        led_pkt[8] = 0;   led_pkt[9] = 0;   led_pkt[10] = 0;   // Rossi
-        led_pkt[11] = 0;  led_pkt[12] = 255; led_pkt[13] = 0;   // Verdi (Power G:255)
-        led_pkt[14] = 0;  led_pkt[15] = 0;   led_pkt[16] = 0;   // Blu
+        // 2. Leggi stato microfono (Reattivo 100ms)
+        int res = hid_read_timeout(h, read_buf, 65, 100);
+        if (res > 0 && read_buf[0] == 0x03 && read_buf[3] == 0xA6) {
+            mic_muted = (read_buf[5] == 1);
+            std::cout << "\rSTATO RILEVATO: " << (mic_muted ? "MUTO" : "ATTIVO") << "    " << std::flush;
+        }
 
-        hid_write(h, led_pkt, 65);
-        std::this_thread::sleep_for(std::chrono::seconds(2));
-        count++;
+        // 3. Sincronizza LED ogni 2 secondi
+        if (std::chrono::duration_cast<std::chrono::seconds>(now - last_led_time).count() >= 2) {
+            unsigned char led_pkt[65] = {0};
+            led_pkt[0] = 0x02; led_pkt[1] = 0x09; led_pkt[2] = 0x06; led_pkt[3] = 0x00;
+            led_pkt[4] = 0x09; 
+            
+            int mr = mic_muted ? 255 : 0;
+            led_pkt[10] = mr;  // Mic (I2)
+            led_pkt[12] = 255; // Power Verde (I1)
+            
+            hid_write(h, led_pkt, 65);
+            last_led_time = now;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
 
     hid_exit();

--- a/test_leds.cpp
+++ b/test_leds.cpp
@@ -55,8 +55,8 @@ int main() {
             std::cout << "\rSTATO RILEVATO: " << (mic_muted ? "MUTO" : "ATTIVO") << "    " << std::flush;
         }
 
-        // 3. Sincronizza LED ogni 2 secondi
-        if (std::chrono::duration_cast<std::chrono::seconds>(now - last_led_time).count() >= 2) {
+        // 3. Sincronizza LED ogni secondo
+        if (std::chrono::duration_cast<std::chrono::seconds>(now - last_led_time).count() >= 1) {
             unsigned char led_pkt[65] = {0};
             led_pkt[0] = 0x02; led_pkt[1] = 0x09; led_pkt[2] = 0x06; led_pkt[3] = 0x00;
             led_pkt[4] = 0x09; 

--- a/test_leds.cpp
+++ b/test_leds.cpp
@@ -4,6 +4,13 @@
 #include <chrono>
 #include <vector>
 
+using Clock = std::chrono::steady_clock;
+constexpr auto MIC_READ_TIMEOUT = std::chrono::milliseconds(100);
+constexpr auto LOOP_SLEEP = std::chrono::milliseconds(50);
+constexpr auto LED_KEEPALIVE_INTERVAL = std::chrono::seconds(2);
+constexpr auto LED_MIN_UPDATE_INTERVAL = std::chrono::milliseconds(250);
+constexpr auto HANDSHAKE_INTERVAL = std::chrono::seconds(10);
+
 void send_cmd(hid_device* handle, const std::vector<unsigned char>& data) {
     unsigned char buf[65] = {0};
     buf[0] = 0x02; buf[1] = 0x09;
@@ -11,6 +18,20 @@ void send_cmd(hid_device* handle, const std::vector<unsigned char>& data) {
         buf[i + 2] = data[i];
     }
     hid_write(handle, buf, 65);
+}
+
+void send_led_state(hid_device* handle, bool mic_muted) {
+    unsigned char led_pkt[65] = {0};
+    led_pkt[0] = 0x02;
+    led_pkt[1] = 0x09;
+    led_pkt[2] = 0x06;
+    led_pkt[3] = 0x00;
+    led_pkt[4] = 0x09;
+
+    led_pkt[10] = mic_muted ? 255 : 0;  // Mic (I2)
+    led_pkt[12] = 255;                  // Power verde (I1)
+
+    hid_write(handle, led_pkt, 65);
 }
 
 int main() {
@@ -35,41 +56,41 @@ int main() {
 
     unsigned char read_buf[65];
     bool mic_muted = false;
-    auto last_led_time = std::chrono::steady_clock::now();
-    auto last_handshake_time = std::chrono::steady_clock::now();
+    bool led_dirty = true;
+    auto last_led_time = Clock::now() - LED_KEEPALIVE_INTERVAL;
+    auto last_handshake_time = Clock::now() - HANDSHAKE_INTERVAL;
 
     while (true) {
-        auto now = std::chrono::steady_clock::now();
+        auto now = Clock::now();
+        bool mic_changed = false;
 
         // 1. Handshake ogni 10 secondi
-        if (std::chrono::duration_cast<std::chrono::seconds>(now - last_handshake_time).count() >= 10) {
+        if (now - last_handshake_time >= HANDSHAKE_INTERVAL) {
             send_cmd(h, {0x01, 0x03, 0x00, 0x02});
             send_cmd(h, {0x0D, 0x00, 0x01});
             last_handshake_time = now;
         }
 
         // 2. Leggi stato microfono (Reattivo 100ms)
-        int res = hid_read_timeout(h, read_buf, 65, 100);
+        int res = hid_read_timeout(h, read_buf, 65, MIC_READ_TIMEOUT.count());
         if (res > 0 && read_buf[0] == 0x03 && read_buf[3] == 0xA6) {
-            mic_muted = (read_buf[5] == 1);
+            bool new_mic_muted = (read_buf[5] == 1);
+            mic_changed = (new_mic_muted != mic_muted);
+            mic_muted = new_mic_muted;
+            led_dirty = led_dirty || mic_changed;
             std::cout << "\rSTATO RILEVATO: " << (mic_muted ? "MUTO" : "ATTIVO") << "    " << std::flush;
         }
 
-        // 3. Sincronizza LED ogni secondo
-        if (std::chrono::duration_cast<std::chrono::seconds>(now - last_led_time).count() >= 1) {
-            unsigned char led_pkt[65] = {0};
-            led_pkt[0] = 0x02; led_pkt[1] = 0x09; led_pkt[2] = 0x06; led_pkt[3] = 0x00;
-            led_pkt[4] = 0x09; 
-            
-            int mr = mic_muted ? 255 : 0;
-            led_pkt[10] = mr;  // Mic (I2)
-            led_pkt[12] = 255; // Power Verde (I1)
-            
-            hid_write(h, led_pkt, 65);
+        // 3. Aggiorna subito sui cambi mic, ma mantieni un keepalive LED stabile.
+        bool led_keepalive_due = (now - last_led_time >= LED_KEEPALIVE_INTERVAL);
+        bool led_change_due = led_dirty && (now - last_led_time >= LED_MIN_UPDATE_INTERVAL);
+        if (led_keepalive_due || led_change_due) {
+            send_led_state(h, mic_muted);
+            led_dirty = false;
             last_led_time = now;
         }
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        std::this_thread::sleep_for(LOOP_SLEEP);
     }
 
     hid_exit();

--- a/test_leds.cpp
+++ b/test_leds.cpp
@@ -1,0 +1,58 @@
+#include <hidapi/hidapi.h>
+#include <iostream>
+#include <thread>
+#include <chrono>
+#include <vector>
+
+void send_cmd(hid_device* handle, const std::vector<unsigned char>& data) {
+    unsigned char buf[65] = {0};
+    buf[0] = 0x02; buf[1] = 0x09;
+    for (size_t i = 0; i < data.size() && (i + 2) < 65; ++i) {
+        buf[i + 2] = data[i];
+    }
+    hid_write(handle, buf, 65);
+}
+
+int main() {
+    if (hid_init()) return 1;
+
+    struct hid_device_info *devs, *cur_dev;
+    devs = hid_enumerate(0x1B1C, 0x0A6B);
+    cur_dev = devs;
+    hid_device* h = nullptr;
+    while (cur_dev) {
+        if (cur_dev->interface_number == 3) {
+            h = hid_open_path(cur_dev->path);
+            if (h) break;
+        }
+        cur_dev = cur_dev->next;
+    }
+    hid_free_enumeration(devs);
+
+    if (!h) return 1;
+
+    std::cout << "BASELINE STABILE: Power Verde, Logo Off, Mic Off." << std::endl;
+
+    int count = 0;
+    while (true) {
+        if (count % 5 == 0) {
+            send_cmd(h, {0x01, 0x03, 0x00, 0x02});
+            send_cmd(h, {0x0D, 0x00, 0x01});
+        }
+
+        unsigned char led_pkt[65] = {0};
+        led_pkt[0] = 0x02; led_pkt[1] = 0x09; led_pkt[2] = 0x06; led_pkt[3] = 0x00;
+        led_pkt[4] = 0x09; 
+        
+        led_pkt[8] = 0;   led_pkt[9] = 0;   led_pkt[10] = 0;   // Rossi
+        led_pkt[11] = 0;  led_pkt[12] = 255; led_pkt[13] = 0;   // Verdi (Power G:255)
+        led_pkt[14] = 0;  led_pkt[15] = 0;   led_pkt[16] = 0;   // Blu
+
+        hid_write(h, led_pkt, 65);
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+        count++;
+    }
+
+    hid_exit();
+    return 0;
+}


### PR DESCRIPTION
Hello, thanks for your program!
I noticed that battery percentage detection sometimes required restarting the headset, and charging status detection was unreliable on my HS80. This PR improves the polling/response handling for battery and charging state, and adds LED control support for the logo, power LED, and microphone LED states.
The microphone LED can be configured separately for muted and unmuted states.

It also adds a tray-accessible settings window to configure LED colors, with settings persisted across restarts.

<img width="325" height="205" alt="image" src="https://github.com/user-attachments/assets/3688f9f8-a12d-4fe5-a807-54701194a2d4" />
